### PR TITLE
fix: waiting for lazy-loaded images always timeouts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,9 @@ function waitForFontLoading() {
 
 // Check if the images are loaded
 function waitForImagesLoading() {
-  return Array.from(document.images).every((img) => img.complete);
+    const allImages = Array.from(document.images);
+    allImages.forEach(img => img.loading = "eager")
+    return allImages.every((img)=>img.complete);
 }
 
 type LocatorOptions = Parameters<Page["locator"]>[1];


### PR DESCRIPTION
## Description

When images have `<img loading="lazy">` the screenshot function always times out.

I think it's a reasonable default to load all images eagerly. 

Not sure it's the appropriate place to perform that side effect or if it's fine to perform it multiple times (normally the docs images remain the same over time? 🤷‍♂️) , but this definitively solves my problem

Example: https://docusaurus.io/blog/2022/08/01/announcing-docusaurus-2.0

Before, timeouts for paths:

```
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /blog =======
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /blog/2018/04/30/How-I-Converted-Profilo-To-Docusaurus 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /blog/2022/01/24/docusaurus-2021-recap 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /blog/2022/08/01/announcing-docusaurus-2.0 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /blog/tags/release 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /community/contributing 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /docs/api/docusaurus-config 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /docs/api/plugins/@docusaurus/plugin-pwa 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /docs/deployment 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /docs/i18n/crowdin 
    [chromium] › siteScreenshots.spec.ts:94:9 › Docusaurus site screenshots › pathname /docs/markdown-features/assets 
```

After: these paths can be screenshotted correctly.

## Type of changes

Select the correct labels: `bug`

## Checklist

Valid all before asking for a code review to `argos-ci/code` :

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [ ] Lint and unit tests pass locally
- [ ] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

