### PR TITLE
feat: wait for detached aria-busy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ const GLOBAL_STYLES = `
     font-family: monospace !important;
     opacity: 0 !important;
   }
-  
+
   [data-visual-test="removed"] {
     display: none !important;
   }
@@ -76,7 +76,7 @@ export async function argosScreenshot(
   await page.addStyleTag({ content: GLOBAL_STYLES });
 
   // Wait for all busy elements to be loaded
-  await page.waitForSelector('[aria-busy="true"]', { state: "hidden" });
+  await page.waitForSelector('[aria-busy="true"]', { state: "detached" });
 
   // Wait for all images and fonts to be loaded
   await Promise.all([


### PR DESCRIPTION
### ⚠️ Breaking changes

In this PR, the state option for [waitForSelector](https://playwright.dev/docs/api/class-page#page-wait-for-selector) is changed from `hidden` to `detached`. Here's the key difference:

- **hidden**: The element is detached from DOM, or has no bounding box or visibility set to hidden.
- **detached**: The element is not present in DOM.

### Why this change?

With Playwright, an empty div isn't considered visible, which is a problem for users using empty div with `aria-busy` to delay the screenshot capture.

